### PR TITLE
Retry fetch on Server Disconnected error

### DIFF
--- a/custom_components/azrouter_integration/api.py
+++ b/custom_components/azrouter_integration/api.py
@@ -146,15 +146,29 @@ class AZRouterIntegrationApiClient:
         data: dict | None = None,
         headers: dict | None = None,
     ) -> Any:
-        """Execute an HTTP request, raising typed exceptions on error."""
+        """
+        Execute an HTTP request, raising typed exceptions on error.
+
+        Retries once on ServerDisconnectedError before giving up.
+        """
         try:
             async with async_timeout.timeout(10):
-                response = await self._session.request(
-                    method=method,
-                    url=url,
-                    headers=headers,
-                    json=data,
-                )
+                try:
+                    response = await self._session.request(
+                        method=method,
+                        url=url,
+                        headers=headers,
+                        json=data,
+                    )
+                except aiohttp.ServerDisconnectedError:
+                    # Router dropped the connection; retry once immediately.
+                    # Any error on the retry propagates to the outer handler.
+                    response = await self._session.request(
+                        method=method,
+                        url=url,
+                        headers=headers,
+                        json=data,
+                    )
                 _verify_response_or_raise(response)
                 return response
 

--- a/custom_components/azrouter_integration/coordinator.py
+++ b/custom_components/azrouter_integration/coordinator.py
@@ -41,7 +41,10 @@ class _ResourceSchedule:
     async def refresh(self, now: datetime) -> None:
         """Fetch and cache a fresh value, recording the fetch time."""
         self.cached = await self.fetch()
-        self.last_fetched = now
+        # Floor to whole second so that HA's int(loop.time())-based scheduler
+        # always fires at least 1 s after last_fetched, preventing every other
+        # poll from being skipped when a fetch lands mid-second (f > μ offset).
+        self.last_fetched = now.replace(microsecond=0)
 
 
 def _build_schedules(


### PR DESCRIPTION
- Attempt to fetch another time when encountered Server Disconnected error.
- Avoid skipping fetch every even attempt (due to schedule aliasing)